### PR TITLE
Fixing some typos in "Command model"

### DIFF
--- a/part2/command-model.md
+++ b/part2/command-model.md
@@ -60,12 +60,12 @@ public class MyAggregate {
     }
     
     // constructor needed by JPA
-    protected MyAggregateRoot() {
+    protected MyAggregate() {
     }
 }
 ```
 
-Entities within an Aggregate can listener to the events the Aggregate publishes, by defining an `@EventHandler` annotated method. These methods will be invoked when an EventMessage is published (before any external handlers are published).
+Entities within an Aggregate can listen to the events the Aggregate publishes, by defining an `@EventHandler` annotated method. These methods will be invoked when an EventMessage is published (before any external handlers are published).
 
 Event sourced aggregates
 ------------------------
@@ -141,7 +141,7 @@ Fields that (may) contain child entities must be annotated with `@AggregateMembe
 
 It is recommended to define the Command Handlers directly in the Aggregate that contains the state to process this command, as it is not unlikely that a command handler needs the state of that Aggregate to do its job. 
 
-To define a Command Handler in an Aggregate, simply annotated the Command Handling method with `@CommandHandler`. The rules for an `@CommandHandler` annotated method are the same as for any handler method. However, Commands are not only routed by their payload. Command Messages carry a name, which defaults to the fully qualified class name of the Command object.
+To define a Command Handler in an Aggregate, simply annotate the Command Handling method with `@CommandHandler`. The rules for an `@CommandHandler` annotated method are the same as for any handler method. However, Commands are not only routed by their payload. Command Messages carry a name, which defaults to the fully qualified class name of the Command object.
 
 By default, `@CommandHandler` annotated methods allow the following parameter types:
 


### PR DESCRIPTION
Fixed some typos and a mistake in a code sample in the "Command model" chapter