### PR TITLE
[#73] Describe Message Dispatch Interceptors for the Event Bus

### DIFF
--- a/part-iii-infrastructure-components/command-dispatching.md
+++ b/part-iii-infrastructure-components/command-dispatching.md
@@ -154,7 +154,7 @@ One of the advantages of using a command bus is the ability to undertake action 
 
 There are different types of interceptors: Dispatch Interceptors and Handler Interceptors. Dispatch Interceptors are invoked before a command is dispatched to a Command Handler. At that point, it may not even be sure that any handler exists for that command. Handler Interceptors are invoked just before the Command Handler is invoked.
 
-### Message Dispatch Interceptors
+### Dispatch Interceptors
 
 Message Dispatch Interceptors are invoked when a command is dispatched on a Command Bus. They have the ability to alter the Command Message, by adding Meta Data, for example, or block the command by throwing an Exception. These interceptors are always invoked on the thread that dispatches the Command.
 
@@ -197,7 +197,7 @@ Axon Framework has support for JSR 303 Bean Validation based validation. This al
 
 The BeanValidationInterceptor also implements `MessageHandlerInterceptor`, allowing you to configure it as a Handler Interceptor as well.
 
-### Message Handler Interceptors
+### Handler Interceptors
 
 Message Handler Interceptors can take action both before and after command processing. Interceptors can even block command processing altogether, for example for security reasons.
 

--- a/part-iii-infrastructure-components/event-processing.md
+++ b/part-iii-infrastructure-components/event-processing.md
@@ -31,6 +31,54 @@ Event Handlers define the business logic to be performed when an Event is receiv
 
 Event Processors come in roughly two forms: Subscribing and Tracking. The Subscribing Event Processors subscribe themselves to a source of Events and are invoked by the thread managed by the publishing mechanism. Tracking Event Processors, on the other hand, pull their messages from a source using a thread that it manages itself.
 
+## Event Interceptors
+
+Similarly as with [Command Messages](command-dispatching.md#command-interceptors), Event Messages can also be intercepted prior to publishing and handling to perform additional actions on all Events.
+This thus boils down to same two types of interceptors for messages: the Dispatch- and the HandlerInterceptor. 
+
+Dispatch Interceptors are invoked before a Event (Message) is published on the Event Bus.  
+Handler Interceptors on the other end are invoked just before the Event Handler is invoked with a given Event (Message) in the Event Processor.
+Examples of operations performed in an interceptor are logging or authentication, which you might want to do regardless of the type of event.
+
+### Dispatch Interceptors
+
+Any Message Dispatch Interceptors registered to an Event Bus will be invoked when a event is published.
+They have the ability to alter the Event Message, by adding Meta Data for example, or they can provide you with overall logging capabilities for when an event is published. 
+These interceptors are always invoked on the thread that published the Event.
+
+Let's create a Event Message Dispatch Interceptor which logs each Event message being published on an `EventBus`.
+```java
+public class EventLoggingDispatchInterceptor implements MessageDispatchInterceptor<EventMessage<?>> {
+
+    private static final Logger logger = LoggerFactory.getLogger(EventLoggingDispatchInterceptor.class);
+    
+    @Override
+    public BiFunction<Integer, EventMessage<?>, EventMessage<?>> handle(List<? extends EventMessage<?>> messages) {
+        return (index, event) -> {
+            logger.info("Publishing event: [{}].", event);
+            return event;
+        };
+    }
+}
+```
+We can then register this dispatch interceptor with an `EventBus` by doing the following:
+```java
+public class EventBusConfiguration {
+    
+    public EventBus configureEventBus(EventStorageEngine eventStorageEngine) {
+        // Note that an EventStore is a more specific implementation of an EventBus
+        EventBus eventBus = new EmbeddedEventStore(eventStorageEngine);
+        eventBus.registerDispatchInterceptor(new EventLoggingDispatchInterceptor());
+        return eventBus;
+    }
+}
+```
+
+> **Note**
+>
+> Different from the `CommandBus` and `QueryBus` which both can have Handler and Dispatch Interceptors, the `EventBus` can only have registered Dispatch Interceptors. This is the case because the event publishing part, so the place which is in control of event message dispatching, is the sole purpose of the Event Bus. The `EventProcessor`s are in charge of handling the event messages, thus contain the Handler Interceptors. 
+
+
 ### Assigning handlers to processors
 
 All processors have a name, which identifies a processor instance across JVM instances. Two processors with the same name, can be considered as two instances of the same processor.

--- a/part-iii-infrastructure-components/event-processing.md
+++ b/part-iii-infrastructure-components/event-processing.md
@@ -37,7 +37,7 @@ Similarly as with [Command Messages](command-dispatching.md#command-interceptors
 This thus boils down to same two types of interceptors for messages: the Dispatch- and the HandlerInterceptor. 
 
 Dispatch Interceptors are invoked before a Event (Message) is published on the Event Bus.  
-Handler Interceptors on the other end are invoked just before the Event Handler is invoked with a given Event (Message) in the Event Processor.
+Handler Interceptors on the other hand are invoked just before the Event Handler is invoked with a given Event (Message) in the Event Processor.
 Examples of operations performed in an interceptor are logging or authentication, which you might want to do regardless of the type of event.
 
 ### Dispatch Interceptors
@@ -46,7 +46,7 @@ Any Message Dispatch Interceptors registered to an Event Bus will be invoked whe
 They have the ability to alter the Event Message, by adding Meta Data for example, or they can provide you with overall logging capabilities for when an event is published. 
 These interceptors are always invoked on the thread that published the Event.
 
-Let's create a Event Message Dispatch Interceptor which logs each Event message being published on an `EventBus`.
+Let's create an Event Message Dispatch Interceptor which logs each Event message being published on an `EventBus`.
 ```java
 public class EventLoggingDispatchInterceptor implements MessageDispatchInterceptor<EventMessage<?>> {
 
@@ -76,8 +76,8 @@ public class EventBusConfiguration {
 
 > **Note**
 >
-> Different from the `CommandBus` and `QueryBus` which both can have Handler and Dispatch Interceptors, the `EventBus` can only have registered Dispatch Interceptors. 
-> This is the case because the event publishing part, so the place which is in control of event message dispatching, is the sole purpose of the Event Bus. 
+> Different from the `CommandBus` and `QueryBus`, which both can have Handler and Dispatch Interceptors, the `EventBus` can only have registered Dispatch Interceptors. 
+> This is the case because the Event publishing part, so the place which is in control of Event Message dispatching, is the sole purpose of the Event Bus. 
 > The `EventProcessor`s are in charge of handling the event messages, thus contain the Handler Interceptors. 
 
 

--- a/part-iii-infrastructure-components/event-processing.md
+++ b/part-iii-infrastructure-components/event-processing.md
@@ -76,7 +76,9 @@ public class EventBusConfiguration {
 
 > **Note**
 >
-> Different from the `CommandBus` and `QueryBus` which both can have Handler and Dispatch Interceptors, the `EventBus` can only have registered Dispatch Interceptors. This is the case because the event publishing part, so the place which is in control of event message dispatching, is the sole purpose of the Event Bus. The `EventProcessor`s are in charge of handling the event messages, thus contain the Handler Interceptors. 
+> Different from the `CommandBus` and `QueryBus` which both can have Handler and Dispatch Interceptors, the `EventBus` can only have registered Dispatch Interceptors. 
+> This is the case because the event publishing part, so the place which is in control of event message dispatching, is the sole purpose of the Event Bus. 
+> The `EventProcessor`s are in charge of handling the event messages, thus contain the Handler Interceptors. 
 
 
 ### Assigning handlers to processors


### PR DESCRIPTION
This PR introduces a `Event Interceptors` section to the `event-processing.md` file.
More specifically it describes the Dispatch Interceptor which might be registered to the `EventBus`.

This PR resolves issue #73 