### PR TITLE
[#72]  Describe Message Handler Interceptors for Event Processors

### DIFF
--- a/part-iii-infrastructure-components/command-dispatching.md
+++ b/part-iii-infrastructure-components/command-dispatching.md
@@ -201,7 +201,9 @@ The BeanValidationInterceptor also implements `MessageHandlerInterceptor`, allow
 
 Message Handler Interceptors can take action both before and after command processing. Interceptors can even block command processing altogether, for example for security reasons.
 
-Interceptors must implement the `MessageHandlerInterceptor` interface. This interface declares one method, `handle`, that takes three parameters: the command message, the current `UnitOfWork` and an `InterceptorChain`. The `InterceptorChain` is used to continue the dispatching process.
+Interceptors must implement the `MessageHandlerInterceptor` interface. 
+This interface declares one method, `handle`, that takes three parameters: the command message, the current `UnitOfWork` and an `InterceptorChain`. 
+The `InterceptorChain` is used to continue the dispatching process, where as the `UnitOfWork` gives you (1) the message being handled and (2) provides the possibility to tie in logic prior, during or after (command) message handling (see [UnitOfWork](../part-i-getting-started#unit-of-work) for more information about the phases).
 
 Unlike Dispatch Interceptors, Handler Interceptors are invoked in the context of the Command Handler. That means they can attach correlation data based on the Message being handled to the Unit of Work, for example. This correlation data will then be attached to messages being created in the context of that Unit of Work.
 

--- a/part-iii-infrastructure-components/command-dispatching.md
+++ b/part-iii-infrastructure-components/command-dispatching.md
@@ -203,7 +203,7 @@ Message Handler Interceptors can take action both before and after command proce
 
 Interceptors must implement the `MessageHandlerInterceptor` interface. 
 This interface declares one method, `handle`, that takes three parameters: the command message, the current `UnitOfWork` and an `InterceptorChain`. 
-The `InterceptorChain` is used to continue the dispatching process, where as the `UnitOfWork` gives you (1) the message being handled and (2) provides the possibility to tie in logic prior, during or after (command) message handling (see [UnitOfWork](../part-i-getting-started#unit-of-work) for more information about the phases).
+The `InterceptorChain` is used to continue the dispatching process, whereas the `UnitOfWork` gives you (1) the message being handled and (2) provides the possibility to tie in logic prior, during or after (command) message handling (see [UnitOfWork](../part-i-getting-started#unit-of-work) for more information about the phases).
 
 Unlike Dispatch Interceptors, Handler Interceptors are invoked in the context of the Command Handler. That means they can attach correlation data based on the Message being handled to the Unit of Work, for example. This correlation data will then be attached to messages being created in the context of that Unit of Work.
 

--- a/part-iii-infrastructure-components/event-processing.md
+++ b/part-iii-infrastructure-components/event-processing.md
@@ -241,7 +241,7 @@ It is recommended to explicitly define an `ErrorHandler` when using the `Asynchr
 ## Event Interceptors
 
 Similarly as with [Command Messages](command-dispatching.md#command-interceptors), Event Messages can also be intercepted prior to publishing and handling to perform additional actions on all Events.
-This thus boils down to same two types of interceptors for messages: the Dispatch- and the HandlerInterceptor. 
+This thus boils down to same two types of interceptors for messages: the Dispatch- and the Handler Interceptor. 
 
 Dispatch Interceptors are invoked before a Event (Message) is published on the Event Bus.  
 Handler Interceptors on the other hand are invoked just before the Event Handler is invoked with a given Event (Message) in the Event Processor.

--- a/part-iii-infrastructure-components/event-processing.md
+++ b/part-iii-infrastructure-components/event-processing.md
@@ -251,7 +251,7 @@ Examples of operations performed in an interceptor are logging or authentication
 
 Any Message Dispatch Interceptors registered to an Event Bus will be invoked when an Event is published.
 They have the ability to alter the Event Message, by adding Meta Data for example, or they can provide you with overall logging capabilities for when an Event is published. 
-These interceptors are always invoked on the thread that published the Event.
+These interceptors are always invoked on the thread that published the Event.w
 
 Let's create an Event Message Dispatch Interceptor which logs each Event message being published on an `EventBus`.
 ```java
@@ -288,7 +288,7 @@ Interceptors can even block Event processing altogether, for example for securit
 
 Interceptors must implement the `MessageHandlerInterceptor` interface. 
 This interface declares one method, `handle`, that takes three parameters: the (Event) Message, the current `UnitOfWork` and an `InterceptorChain`. 
-The `InterceptorChain` is used to continue the dispatching process, where as the `UnitOfWork` gives you (1) the message being handled and (2) provides the possibility to tie in logic prior, during or after (event) message handling (see [UnitOfWork](../part-i-getting-started#unit-of-work) for more information about the phases). 
+The `InterceptorChain` is used to continue the dispatching process, whereas the `UnitOfWork` gives you (1) the message being handled and (2) provides the possibility to tie in logic prior, during or after (event) message handling (see [UnitOfWork](../part-i-getting-started#unit-of-work) for more information about the phases). 
 
 Unlike Dispatch Interceptors, Handler Interceptors are invoked in the context of the Event Handler. 
 That means they can attach correlation data based on the Message being handled to the Unit of Work, for example. 

--- a/part-iii-infrastructure-components/event-processing.md
+++ b/part-iii-infrastructure-components/event-processing.md
@@ -251,7 +251,7 @@ Examples of operations performed in an interceptor are logging or authentication
 
 Any Message Dispatch Interceptors registered to an Event Bus will be invoked when an Event is published.
 They have the ability to alter the Event Message, by adding Meta Data for example, or they can provide you with overall logging capabilities for when an Event is published. 
-These interceptors are always invoked on the thread that published the Event.w
+These interceptors are always invoked on the thread that published the Event.
 
 Let's create an Event Message Dispatch Interceptor which logs each Event message being published on an `EventBus`.
 ```java

--- a/part-iii-infrastructure-components/event-processing.md
+++ b/part-iii-infrastructure-components/event-processing.md
@@ -38,12 +38,12 @@ This thus boils down to same two types of interceptors for messages: the Dispatc
 
 Dispatch Interceptors are invoked before a Event (Message) is published on the Event Bus.  
 Handler Interceptors on the other hand are invoked just before the Event Handler is invoked with a given Event (Message) in the Event Processor.
-Examples of operations performed in an interceptor are logging or authentication, which you might want to do regardless of the type of event.
+Examples of operations performed in an interceptor are logging or authentication, which you might want to do regardless of the type of Event.
 
 ### Dispatch Interceptors
 
-Any Message Dispatch Interceptors registered to an Event Bus will be invoked when a event is published.
-They have the ability to alter the Event Message, by adding Meta Data for example, or they can provide you with overall logging capabilities for when an event is published. 
+Any Message Dispatch Interceptors registered to an Event Bus will be invoked when an Event is published.
+They have the ability to alter the Event Message, by adding Meta Data for example, or they can provide you with overall logging capabilities for when an Event is published. 
 These interceptors are always invoked on the thread that published the Event.
 
 Let's create an Event Message Dispatch Interceptor which logs each Event message being published on an `EventBus`.
@@ -76,8 +76,8 @@ public class EventBusConfiguration {
 
 ### Handler Interceptors
 
-Message Handler Interceptors can take action both before and after event processing. 
-Interceptors can even block event processing altogether, for example for security reasons.
+Message Handler Interceptors can take action both before and after Event processing. 
+Interceptors can even block Event processing altogether, for example for security reasons.
 
 Interceptors must implement the `MessageHandlerInterceptor` interface. 
 This interface declares one method, `handle`, that takes three parameters: the (Event) Message, the current `UnitOfWork` and an `InterceptorChain`. 
@@ -87,8 +87,8 @@ Unlike Dispatch Interceptors, Handler Interceptors are invoked in the context of
 That means they can attach correlation data based on the Message being handled to the Unit of Work, for example. 
 This correlation data will then be attached to Event Messages being created in the context of that Unit of Work.
 
-Let's create a Message Handler Interceptor which will only allow the handling of events that contain `axonUser` as a value for the `userId` field in the `MetaData`. 
-If the `userId` is not present in the meta-data, an exception will be thrown which will prevent the event from being handled. 
+Let's create a Message Handler Interceptor which will only allow the handling of Events that contain `axonUser` as a value for the `userId` field in the `MetaData`. 
+If the `userId` is not present in the meta-data, an exception will be thrown which will prevent the Event from being handled. 
 And if the `userId`'s value does not match `axonUser`, we will also not proceed up the chain.
 Authenticating the Event Message like shown in this example is a regular use case of the `MessageHandlerInterceptor`. 
 

--- a/part-iii-infrastructure-components/event-processing.md
+++ b/part-iii-infrastructure-components/event-processing.md
@@ -123,8 +123,8 @@ public class EventProcessorConfiguration {
 > **Note**
 >
 > Different from the `CommandBus` and `QueryBus`, which both can have Handler and Dispatch Interceptors, the `EventBus` can only have registered Dispatch Interceptors. 
-> This is the case because the Event publishing part, so the place which is in control of Event Message dispatching, is the sole purpose of the Event Bus. 
-> The `EventProcessor`s are in charge of handling the event messages, thus are the spot where the Handler Interceptors are registered. 
+> This is the case because the Event publishing part, so the place which is in control of Event Message dispatching, is the sole purpose of the Event Bus.
+> The `EventProcessor`s are in charge of handling the Event Messages, thus are the spot where the Handler Interceptors are registered. 
 
 
 ### Assigning handlers to processors

--- a/part-iii-infrastructure-components/query-processing.md
+++ b/part-iii-infrastructure-components/query-processing.md
@@ -48,7 +48,9 @@ The BeanValidationInterceptor also implements `MessageHandlerInterceptor`, allow
 
 Message Handler Interceptors can take action both before and after query processing. Interceptors can even block query processing altogether, for example for security reasons.
 
-Interceptors must implement the `MessageHandlerInterceptor` interface. This interface declares one method, `handle`, that takes three parameters: the query message, the current `UnitOfWork` and an `InterceptorChain`. The `InterceptorChain` is used to continue the dispatching process.
+Interceptors must implement the `MessageHandlerInterceptor` interface. 
+This interface declares one method, `handle`, that takes three parameters: the query message, the current `UnitOfWork` and an `InterceptorChain`. 
+The `InterceptorChain` is used to continue the dispatching process, where as the `UnitOfWork` gives you (1) the message being handled and (2) provides the possibility to tie in logic prior, during or after (query) message handling (see [UnitOfWork](../part-i-getting-started#unit-of-work) for more information about the phases).
 
 Unlike Dispatch Interceptors, Handler Interceptors are invoked in the context of the Query Handler. That means they can attach correlation data based on the Message being handled to the Unit of Work, for example. This correlation data will then be attached to messages being created in the context of that Unit of Work.
 

--- a/part-iii-infrastructure-components/query-processing.md
+++ b/part-iii-infrastructure-components/query-processing.md
@@ -50,7 +50,7 @@ Message Handler Interceptors can take action both before and after query process
 
 Interceptors must implement the `MessageHandlerInterceptor` interface. 
 This interface declares one method, `handle`, that takes three parameters: the query message, the current `UnitOfWork` and an `InterceptorChain`. 
-The `InterceptorChain` is used to continue the dispatching process, where as the `UnitOfWork` gives you (1) the message being handled and (2) provides the possibility to tie in logic prior, during or after (query) message handling (see [UnitOfWork](../part-i-getting-started#unit-of-work) for more information about the phases).
+The `InterceptorChain` is used to continue the dispatching process, whereas the `UnitOfWork` gives you (1) the message being handled and (2) provides the possibility to tie in logic prior, during or after (query) message handling (see [UnitOfWork](../part-i-getting-started#unit-of-work) for more information about the phases).
 
 Unlike Dispatch Interceptors, Handler Interceptors are invoked in the context of the Query Handler. That means they can attach correlation data based on the Message being handled to the Unit of Work, for example. This correlation data will then be attached to messages being created in the context of that Unit of Work.
 

--- a/part-iv-advanced-tuning/metrics-and-monitoring.md
+++ b/part-iv-advanced-tuning/metrics-and-monitoring.md
@@ -102,7 +102,7 @@ public class MonitoringConfiguration {
 ### Interceptor Logging
 
 Another good approach to track the flow of messages throughout an Axon application is by setting up the right interceptors in your application.  
-As you might now there are two flavors of interceptors, the Dispatch and Handler interceptors (like discussed [here](../part-iii-infrastructure-components/command-dispatching.md#command-interceptors) for commands and [here](../part-iii-infrastructure-components/query-processing.md#handler-interceptors) for queries), which intercept a message prior to publishing (Dispatch Interceptor) or whilst it is being handled (Handler Interceptor).
+As you might now there are two flavors of interceptors, the Dispatch and Handler interceptors (like discussed [here](../part-iii-infrastructure-components/command-dispatching.md#command-interceptors) for commands, [here](../part-iii-infrastructure-components/event-processing.md#event-interceptors) for events and [here](../part-iii-infrastructure-components/query-processing.md#handler-interceptors) for queries), which intercept a message prior to publishing (Dispatch Interceptor) or whilst it is being handled (Handler Interceptor).
 The interceptor mechanism lends itself quite nicely to introduce a way to consistently log when a message is being dispatched/handled.
 The `LoggingInterceptor` is an out of the box solution to log any type of message to SLF4J, but also provides a simple overridable template to set up your own desired logging format. 
 We refer to the command, event and query sections for the specifics on how to configure message interceptors.

--- a/part-iv-advanced-tuning/metrics-and-monitoring.md
+++ b/part-iv-advanced-tuning/metrics-and-monitoring.md
@@ -111,7 +111,7 @@ public class MonitoringConfiguration {
 ### Interceptor Logging
 
 Another good approach to track the flow of messages throughout an Axon application is by setting up the right interceptors in your application.  
-As you might now there are two flavors of interceptors, the Dispatch and Handler interceptors (like discussed [here](../part-iii-infrastructure-components/command-dispatching.md#command-interceptors) for commands, [here](../part-iii-infrastructure-components/event-processing.md#event-interceptors) for events and [here](../part-iii-infrastructure-components/query-processing.md#handler-interceptors) for queries), which intercept a message prior to publishing (Dispatch Interceptor) or whilst it is being handled (Handler Interceptor).
+There are two flavors of interceptors, the Dispatch and Handler Interceptors (like discussed [here](../part-iii-infrastructure-components/command-dispatching.md#command-interceptors) for commands, [here](../part-iii-infrastructure-components/event-processing.md#event-interceptors) for events and [here](../part-iii-infrastructure-components/query-processing.md#handler-interceptors) for queries), which intercept a message prior to publishing (Dispatch Interceptor) or whilst it is being handled (Handler Interceptor).
 The interceptor mechanism lends itself quite nicely to introduce a way to consistently log when a message is being dispatched/handled.
 The `LoggingInterceptor` is an out of the box solution to log any type of message to SLF4J, but also provides a simple overridable template to set up your own desired logging format. 
 We refer to the command, event and query sections for the specifics on how to configure message interceptors.


### PR DESCRIPTION
This PR introduces a `Handler Interceptors` section to the `event-processing.md` file, describing what it does and how you can create and register one to your `EventProcessor`s.
I have additionally made a small adjustment to the handler interceptor description of the command and query section, fine tuning the usage of the `UnitOfWork` in there.

Lastly I have linked to the `event interceptors` section in the `metrics-and-monitoring.md` section, as that part was missing there whilst the query and command side links were represented.

This PR resolves issue #72 