### PR TITLE
[#70] Describe configuring metrics through Spring Boot

### DIFF
--- a/part-iv-advanced-tuning/metrics-and-monitoring.md
+++ b/part-iv-advanced-tuning/metrics-and-monitoring.md
@@ -36,7 +36,7 @@ public class MetricsConfiguration {
         globalMetricRegistry.registerWithConfigurer(configurer);
     }
 } 
-{%- language name="Spring Boot AutoConfiguration", type="yml" -%}
+{%- language name="Spring Boot AutoConfiguration", type="properties" -%}
 
 # The default value is `true`. Thus you will have Metrics configured if axon-metrics and io.dropwizard.metrics are on your classpath.
 axon.metrics.auto-configuration.enabled=true

--- a/part-iv-advanced-tuning/metrics-and-monitoring.md
+++ b/part-iv-advanced-tuning/metrics-and-monitoring.md
@@ -22,7 +22,9 @@ You are free to configure any combination of `MessageMonitors` through construct
 The `GlobalMetricRegistry` contained in the `axon-metrics` module provides a set of sensible defaults per type of messaging component.
 The following example shows you how to configure default metrics for your message handling components: 
 
-{% codetabs name="Axon Configuration API", type="java" -%}
+{% tabs %}
+{% tab title="Axon Configuration API" %}
+```java
 public class MetricsConfiguration {
     
     public Configurer buildConfigurer() {
@@ -36,12 +38,16 @@ public class MetricsConfiguration {
         globalMetricRegistry.registerWithConfigurer(configurer);
     }
 } 
-{%- language name="Spring Boot AutoConfiguration", type="properties" -%}
+```
+{% endtab %}
 
+{% tab title="Spring Boot AutoConfiguration" %}
+```text
 # The default value is `true`. Thus you will have Metrics configured if axon-metrics and io.dropwizard.metrics are on your classpath.
 axon.metrics.auto-configuration.enabled=true
-
-{%- endcodetabs %}
+```
+{% endtab %}
+{% endtabs %}
 
 If you want to have more specific metrics on a message handling component like the `EventBus`, you can do the following:
 

--- a/part-iv-advanced-tuning/metrics-and-monitoring.md
+++ b/part-iv-advanced-tuning/metrics-and-monitoring.md
@@ -42,7 +42,7 @@ public class MetricsConfiguration {
 {% endtab %}
 
 {% tab title="Spring Boot AutoConfiguration" %}
-```text
+```properties
 # The default value is `true`. Thus you will have Metrics configured if axon-metrics and io.dropwizard.metrics are on your classpath.
 axon.metrics.auto-configuration.enabled=true
 ```

--- a/part-iv-advanced-tuning/metrics-and-monitoring.md
+++ b/part-iv-advanced-tuning/metrics-and-monitoring.md
@@ -20,9 +20,9 @@ The following monitor implementations are currently provided:
 
 You are free to configure any combination of `MessageMonitors` through constructors on your messaging components, and even simpler by using the [Configuration API](../part-i-getting-started/configuration-api.md).
 The `GlobalMetricRegistry` contained in the `axon-metrics` module provides a set of sensible defaults per type of messaging component.
-The following example shows you how to configure default metrics for your components, but also a specific metrics set for your EventBus: 
+The following example shows you how to configure default metrics for your message handling components: 
 
-```java
+{% codetabs name="Axon Configuration API", type="java" -%}
 public class MetricsConfiguration {
     
     public Configurer buildConfigurer() {
@@ -35,10 +35,25 @@ public class MetricsConfiguration {
         // We register the default monitors to our messaging components by doing the following
         globalMetricRegistry.registerWithConfigurer(configurer);
     }
+} 
+{%- language name="Spring Boot AutoConfiguration", type="yml" -%}
 
-    public void configureSpecificEventBusMetrics(Configurer configurer, MetricRegistry metricRegistry) {
-        // So all our messaging components are now set, but we want a different set of metrics for our EventBus
-        // More specifically, we want to count the messages per type of event being published.
+# The default value is `true`. Thus you will have Metrics configured if axon-spring-boot-autoconfigure and io.dropwizard.metrics are on your classpath.
+axon.metrics.auto-configuration.enabled=true
+
+{%- endcodetabs %}
+
+If you want to have more specific metrics on a message handling component like the `EventBus`, you can do the following:
+
+```java
+public class MetricsConfiguration {
+    
+    public Configurer buildConfigurer() {
+        return DefaultConfigurer.defaultConfiguration();
+    }
+
+    public void configureSpecificEventBusMetrics(Configurer configurer, MetricRegistry metricRegistry) { 
+        // For the EventBus we want to count the messages per type of event being published.
         PayloadTypeMessageMonitorWrapper<MessageCountingMonitor> messageCounterPerType =
                 new PayloadTypeMessageMonitorWrapper<>(MessageCountingMonitor::new);
         // And we also want to set a message timer per payload type
@@ -56,8 +71,8 @@ public class MetricsConfiguration {
         eventBusRegistry.register("messageTimerPerType", messageTimerPerType);
         metricRegistry.register("eventBus", eventBusRegistry);
     }
-    
 } 
+
 ```
 
 ## Monitoring

--- a/part-iv-advanced-tuning/metrics-and-monitoring.md
+++ b/part-iv-advanced-tuning/metrics-and-monitoring.md
@@ -38,7 +38,7 @@ public class MetricsConfiguration {
 } 
 {%- language name="Spring Boot AutoConfiguration", type="yml" -%}
 
-# The default value is `true`. Thus you will have Metrics configured if axon-spring-boot-autoconfigure and io.dropwizard.metrics are on your classpath.
+# The default value is `true`. Thus you will have Metrics configured if axon-metrics and io.dropwizard.metrics are on your classpath.
 axon.metrics.auto-configuration.enabled=true
 
 {%- endcodetabs %}


### PR DESCRIPTION
This PR provides some additional description how to configure Metrics if you are using Spring Boot.
It does so by splitting the existing example in two and showing the application properties way of setting metrics if you have both on the classpath.

This PR resolve #70 