### PR TITLE
[#61] Publish content as epub and/or pdf

### DIFF
--- a/README-local.txt
+++ b/README-local.txt
@@ -16,5 +16,19 @@ Alternatively, you can use:
 
 $ ./node_modules/gitbook-cli/bin/gitbook.js serve
 
-This starts a webserver at port 4000; it also monitors your .md files for
-changes, rebuilds the book and refreshes your browser tab.
+This starts a webserver at port 4000;
+It also monitors your .md files for changes, rebuilds the book and refreshes your browser tab.
+
+Additionally, if you want to create a eBook from the reference guide (.pdf, .epbu or .mobi), you can do the following.
+
+Ensure you have Calibre (https://calibre-ebook.com/download) installed locally, as that's what's used under the covers.
+
+Added to that, ensure to install `ebook-convert` through `npm install` (like so `npm install ebook-convert`).
+
+After that, you can run the following from the reference guide root directory:
+
+$ gitbook pdf ./ ./ref-guide.pdf
+
+In doing so you will receive a .pdf of the reference guide.
+
+See https://toolchain.gitbook.com/ebook.html for a short explanation around the GitBook to eBook conversion.

--- a/book.json
+++ b/book.json
@@ -1,5 +1,11 @@
 {
-  "plugins": ["ga", "anchors", "codetabs"],
+  "plugins": [
+    "ga",
+    "anchors",
+    "codetabs",
+    "hints",
+    "simpletabs"
+  ],
   "pluginsConfig": {
     "ga": {
       "token": "UA-180286-13"

--- a/part-ii-domain-logic/command-model.md
+++ b/part-ii-domain-logic/command-model.md
@@ -231,9 +231,7 @@ public class DoSomethingCommand {
 
 Let's see how we can configure an Aggregate:
 
-{% tabs %}
-{% tab title="Axon Configuration API" %}
-```java
+{% codetabs name="Axon Configuration API", type="java" -%}
 Configurer configurer = ...
 // to use defaults:
 configurer.configureAggreate(MyAggregate.class);
@@ -243,10 +241,7 @@ configurer.configureAggregate(
         AggregateConfigurer.defaultConfiguration(MyAggregate.class)
                            .configureCommandTargetResolver(c -> new CustomCommandTargetResolver())
 );
-```
-{% endtab %}
-{% tab title="Spring Boot AutoConfiguration" %}
-```java
+{%- language name="Spring Boot AutoConfiguration", type="java" -%}
 @Aggregate(commandTargetResolver = "customCommandTargetResolver")
 public class MyAggregate {...}
 ...
@@ -255,9 +250,7 @@ public class MyAggregate {...}
 public CommandTargetResolver customCommandTargetResolver() {
     return new CustomCommandTargetResolver();
 }
-```
-{% endtab %}
-{% endtabs %}
+{%- endcodetabs %} 
 
 `@CommandHandler` annotations are not limited to the aggregate root. Placing all command handlers in the root will sometimes lead to a large number of methods on the aggregate root, while many of them simply forward the invocation to one of the underlying entities. If that is the case, you may place the `@CommandHandler` annotation on one of the underlying entities' methods. For Axon to find these annotated methods, the field declaring the entity in the aggregate root must be marked with `@AggregateMember`. Note that only the declared type of the annotated field is inspected for Command Handlers. If a field value is null at the time an incoming command arrives for that entity, an exception is thrown.
 

--- a/part-ii-domain-logic/event-handling.md
+++ b/part-ii-domain-logic/event-handling.md
@@ -57,9 +57,7 @@ Event Handling components are defined using an `EventHandlingConfiguration` clas
 
 To register objects with `@EventHandler` methods, use the `registerEventHandler` method on the `EventHandlingConfiguration`:
 
-{% tabs %}
-{% tab title="Axon Configuration API" %}
-```java
+{% codetabs name="Axon Configuration API", type="java" -%}
 // define an EventHandlingConfiguration
 EventHandlingConfiguration ehConfiguration = new EventHandlingConfiguration()
     .registerEventHandler(conf -> new MyEventHandlerClass());
@@ -67,18 +65,12 @@ EventHandlingConfiguration ehConfiguration = new EventHandlingConfiguration()
 // the module needs to be registered with the Axon Configuration
 Configurer axonConfigurer = DefaultConfigurer.defaultConfiguration()
     .registerModule(ehConfiguration);
-```
-{% endtab %}
-
-{% tab title="Spring Boot AutoConfiguration" %}
-```java
+{%- language name="Spring Boot AutoConfiguration", type="java" -%}
 @Component
 public class MyEventHandlerClass {
     // contains @EventHandler(s)
 }
-```
-{% endtab %}
-{% endtabs %}
+{%- endcodetabs %}
 
 See [Event Handling Configuration](../part-iii-infrastructure-components/spring-boot-autoconfiguration.md#event-handling-configuration) for details on registering event handlers using Spring AutoConfiguration.
 

--- a/part-ii-domain-logic/query-handling.md
+++ b/part-ii-domain-logic/query-handling.md
@@ -61,9 +61,7 @@ In the example above, the handler method of `SubHandler` will be invoked for que
 
 It is possible to register multiple query handlers for the same query name and type of response. When dispatching queries, the client can indicate whether he wants a result from one or from all available query handlers.
 
-{% tabs %}
-{% tab title="Axon Configuration API" %}
-```java
+{% codetabs name="Axon Configuration API", type="java" -%}
 // Sample query handler
 public class MyQueryHandler {
     @QueryHandler
@@ -77,11 +75,7 @@ public class MyQueryHandler {
 // To register your query handler
 Configurer axonConfigurer = DefaultConfigurer.defaultConfiguration()
     .registerQueryHandler(conf -> new MyQueryHandler);
-```
-{% endtab %}
-
-{% tab title="Spring Boot AutoConfiguration" %}
-```java
+{%- language name="Spring Boot AutoConfiguration", type="java" -%}
 // Sample query handler
 @Component
 public class MyQueryHandler {
@@ -90,6 +84,4 @@ public class MyQueryHandler {
         return echo;
     }
 }
-```
-{% endtab %}
-{% endtabs %}
+{%- endcodetabs %}

--- a/part-ii-domain-logic/sagas.md
+++ b/part-ii-domain-logic/sagas.md
@@ -142,9 +142,7 @@ Axon supports life cycle management through the `AnnotatedSagaManager`, which is
 
 When using the Configuration API, Axon will use sensible defaults for most components. However, it is highly recommended to define a `SagaStore` implementation to use. The `SagaStore` is the mechanism that 'physically' stores the Saga instances somewhere. The `AnnotatedSagaRepository` \(the default\) uses the `SagaStore` to store and retrieve Saga instances as they are required.
 
-{% tabs %}
-{% tab title="Axon Configuration API" %}
-```java
+{% codetabs name="Axon Configuration API", type="java" -%}
 Configurer configurer = DefaultConfigurer.defaultConfiguration();
 configurer.registerModule(
         SagaConfiguration.subscribingSagaManager(MySaga.class)
@@ -153,11 +151,7 @@ configurer.registerModule(
 
 // alternatively, it is possible to register a single SagaStore for all Saga types:
 configurer.registerComponent(SagaStore.class, c -> new JpaSagaStore(...));
-```
-{% endtab %}
-
-{% tab title="Spring Boot AutoConfiguration" %}
-```java
+{%- language name="Spring Boot AutoConfiguration", type="java" -%}
 @Saga(sagaStore = "mySagaStore")
 public class MySaga {...}
 ...
@@ -166,9 +160,7 @@ public class MySaga {...}
 public SagaStore mySagaStore() {
     return new MongoSagaStore(...); // default is JpaSagaStore
 }
-```
-{% endtab %}
-{% endtabs %}
+{%- endcodetabs %}
 
 ### Saga Repository and Saga Store
 

--- a/part-iii-infrastructure-components/event-processing.md
+++ b/part-iii-infrastructure-components/event-processing.md
@@ -12,26 +12,18 @@ The `EventBus` is the mechanism that dispatches events to the subscribed event h
 
 When using the Configuration API, the `SimpleEventBus` is used by default. To configure the `EmbeddedEventStore` instead, you need to supply an implementation of a StorageEngine, which does the actual storage of Events.
 
-{% tabs %}
-{% tab title="Axon Configuration API" %}
-```java
-Configurer configurer = DefaultConfigurer.defaultConfiguration();
-configurer.configureEmbeddedEventStore(c -> new InMemoryEventStorageEngine());
-```
-{% endtab %}
-
-{% tab title="Spring Boot AutoConfiguration" %}
-```java
+{% codetabs name="Axon Configuration API", type="java" -%}
+    Configurer configurer = DefaultConfigurer.defaultConfiguration();
+    configurer.configureEmbeddedEventStore(c -> new InMemoryEventStorageEngine());
+{%- language name="Spring Boot AutoConfiguration", type="java" -%}
 // somewhere in configuration
 @Bean
 public EventStorageEngine eventStorageEngine() {
     return new InMemoryEventStorageEngine(); 
 }
-// When a EventStorageEngine is provided, the EmbeddedEventStore is configured as the EventStore.
-// And if JPA configuration is detected JpaEventStorageEngine is configured as EventStorageEngine.
-```
-{% endtab %}
-{% endtabs %}
+// When StorageEngine is provided EmbeddedEventStore is configured as EventStore.
+// If JPA configuration is detected JpaEventStorageEngine is configured as EventStorageEngine.
+{%- endcodetabs %}
 
 ## Event Processors
 

--- a/part-iv-advanced-tuning/advanced-customizations.md
+++ b/part-iv-advanced-tuning/advanced-customizations.md
@@ -24,9 +24,7 @@ There is an implicit ordering between the configurable serializer. If no Event `
 
 See the following example on how to configure each serializer specifically, were we use `XStreamSerializer` as the default and `JacksonSerializer` for all our messages: 
 
-{% tabs %}
-{% tab title="Axon Configuration API" %}
-```java
+{% codetabs name="Axon Configuration API", type="java" -%}
 public class SerializerConfiguration {
     
     public void serializerConfiguration(Configurer configurer) {
@@ -40,27 +38,19 @@ public class SerializerConfiguration {
                   .configureEventSerializer(configuration -> messageSerializer);
     }
 }
-```
-{% endtab %}
-{% tab title="Spring Boot AutoConfiguration - Properties file" %}
-```properties
+{%- language name="Spring Boot AutoConfiguration - Properties file", type="properties" -%}
 # Possible values for these keys are `default`, `xstream`, `java`, and `jackson`.
 axon.serializer.general
 axon.serializer.events
 axon.serializer.messages
-```
-{% endtab %}
-{% tab title="Spring Boot AutoConfiguration - YML file" %}
-```yaml
+{%- language name="Spring Boot AutoConfiguration - YML file", type="yaml" -%}
 # Possible values for these keys are `default`, `xstream`, `java`, and `jackson`.
 axon:
     serializer:
         general: 
         events: 
         messages: 
-```
-{% endtab %}
-{% endtabs %}
+{%- endcodetabs %}
 
 ## Meta Annotations
 

--- a/part-iv-advanced-tuning/metrics-and-monitoring.md
+++ b/part-iv-advanced-tuning/metrics-and-monitoring.md
@@ -22,9 +22,7 @@ You are free to configure any combination of `MessageMonitors` through construct
 The `GlobalMetricRegistry` contained in the `axon-metrics` module provides a set of sensible defaults per type of messaging component.
 The following example shows you how to configure default metrics for your message handling components: 
 
-{% tabs %}
-{% tab title="Axon Configuration API" %}
-```java
+{% codetabs name="Axon Configuration API", type="java" -%}
 public class MetricsConfiguration {
     
     public Configurer buildConfigurer() {
@@ -38,16 +36,10 @@ public class MetricsConfiguration {
         globalMetricRegistry.registerWithConfigurer(configurer);
     }
 } 
-```
-{% endtab %}
-
-{% tab title="Spring Boot AutoConfiguration" %}
-```properties
+{%- language name="Spring Boot AutoConfiguration", type="properties" -%}
 # The default value is `true`. Thus you will have Metrics configured if axon-metrics and io.dropwizard.metrics are on your classpath.
 axon.metrics.auto-configuration.enabled=true
-```
-{% endtab %}
-{% endtabs %}
+{%- endcodetabs %}
 
 If you want to have more specific metrics on a message handling component like the `EventBus`, you can do the following:
 
@@ -94,9 +86,7 @@ This interface and its implementations provide you the means to populate the met
 
 For configuring the `MessageOriginProvider` you can do the following:
 
-{% tabs %}
-{% tab title="Axon Configuration API" %}
-```java
+{% codetabs name="Axon Configuration API", type="java" -%}
 public class MonitoringConfiguration {
     
     public Configurer buildConfigurer() {
@@ -112,11 +102,7 @@ public class MonitoringConfiguration {
     }
     
 }
-```
-{% endtab %}
-
-{% tab title="Spring Boot AutoConfiguration" %}
-```java
+{%- language name="Spring Boot AutoConfiguration", type="java" -%}
 public class MonitoringConfiguration {
 
     // When using Spring Boot, simply defining a CorrelationDataProvider bean is sufficient
@@ -125,9 +111,7 @@ public class MonitoringConfiguration {
     }
 
 }
-```
-{% endtab %}
-{% endtabs %}
+{%- endcodetabs %}
 
 ### Interceptor Logging
 


### PR DESCRIPTION
This PR introduces some preliminary investigation / work around being able to generate an eBook, albeit `.pdf`, `.epub` or `.mobi`, from the Reference Guide.
I have not set it so it's published on any of our websites (as I do not have the credentials for that), but did get it to build locally.
To get to that point, I had to do a couple of things:

- Add more plugins, as those are needed by the eBook conversion tool, being `hints` and `simpletabs`.
- Install [Calibre](https://calibre-ebook.com/download) locally, as that's what the eBook conversion tool uses under the covers.
- Install the `ebook-convert` plugin through `npm`, like so: `npm install ebook-convert`. 
- The plugin necessity was described on the GitBook eBook [page](https://toolchain.gitbook.com/ebook.html), which also described how to generate a `.pdf`/`.epub`/`.mobi` file.
- Running the `gitbook pdf ./ ./ref-guide.pdf` command showed me that the `tabs` blocks didn't work for the conversion tool. Hence, I reverted back to the `codetabs` instead.

Last point of interest is that the Code Tabs quite logically did not work in the eBooks.
Hence we might have to rethink either the the code tabs or the clarity of a published eBook.